### PR TITLE
Reading the previous zip code from local storage

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -22,6 +22,8 @@ var getZip;
 var zoneResults = document.querySelector(".zoneResults");
 var results = document.querySelector(".results");
 
+getZip = localStorage.getItem('zip') || '98052';
+
 // Defines the request for community gardens
 var requestGardens = {
   location: coords,
@@ -63,8 +65,8 @@ var initMap = function () {
 
   service = new google.maps.places.PlacesService(map);
 
-  getCommunityGardens(requestGardens);
-
+  geocode({ address: getZip });
+  getAgZone(getZip);
 
 };
 
@@ -154,7 +156,7 @@ searchBtn.addEventListener("click", function (event) {
 
     console.log(getZip);
     // this is optional, if we don't want to store zipcodes we can scratch this
-    localStorage.setItem("zip", JSON.stringify(getZip));
+    localStorage.setItem("zip", getZip);
     geocode({ address: getZip });
     getAgZone(getZip);
     if ($zipModal.css('visibility') === 'hidden') {
@@ -173,7 +175,7 @@ searchBtn.addEventListener("click", function (event) {
 var getAgZone = function (getZip) {
   // stitch the zipcode into the API URL
   var agURL = "https://c0bra.api.stdlib.com/zipcode-to-hardiness-zone/?zipcode=" + getZip;
-
+  console.log(agURL);
   fetch(agURL)
   .then(function (response) {
     return response.json();
@@ -188,4 +190,3 @@ var getAgZone = function (getZip) {
     results.appendChild(link);
   });
 }
-

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-    <script async src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDIbBrG_X6bfdgaSs7u-AHnysix2GZ86-4&libraries=places&callback=initMap"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB-9BRrSkX6Lxo5ckcJ0ogdvMOyWhA2QvQ&libraries=places&callback=initMap"></script>
     <script src="https://code.iconify.design/2/2.1.2/iconify.min.js"></script>
     <script src="./assets/js/script.js"></script>
 


### PR DESCRIPTION
Reading the previously searched zip code from local storage or setting default to Redmond
Deferring google script load to prevent an error on initial loads.
Initial map and community garden load is now based on the stored zip or default.