### PR TITLE
Hide the zip code modal on load

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -43,6 +43,7 @@ $modal.dialog({
 });
 
 var init = function () {
+  $zipModal.hide();
   geocode({ address: getZip });
   getAgZone(getZip);
 }


### PR DESCRIPTION
Hiding the zip code validation modal on load. And only display it as needed.